### PR TITLE
Fix compact function implementation to fix the transition mixin

### DIFF
--- a/compass.inc.php
+++ b/compass.inc.php
@@ -2,7 +2,7 @@
 
 class scss_compass {
 	protected $libFunctions = array("lib_compact");
-	
+
 	static public $true = array("keyword", "true");
 	static public $false = array("keyword", "false");
 
@@ -27,15 +27,22 @@ class scss_compass {
 	}
 
 	public function lib_compact($args) {
-		list($list) = $args;
-		if ($list[0] != "list") return $list;
-
+		$list = $args;
+		$separator = ',';
 		$filtered = array();
-		foreach ($list[2] as $item) {
-			if ($item != self::$false) $filtered[] = $item;
+
+		if (count($args) == 1 && $args[0][0] == 'list') {
+			$list = $args[0][2];
+			$separator = $args[0][1];
 		}
-		$list[2] = $filtered;
-		return $list;
+
+		foreach ($list as $item) {
+			if ($item != self::$false) {
+				$filtered[] = $item;
+			}
+		}
+
+		return array('list', $separator, $filtered);
 	}
 }
 


### PR DESCRIPTION
I made the `lib_compact` function in `compass.inc.php` more like the original Ruby implementation at https://github.com/chriseppstein/compass/blob/stable/lib/compass/sass_extensions/functions/lists.rb#L18.

The function returns a new list after removing any non-true values.

Scss:

```
.test1 {
    content: compact(value1, value2, false, value3);
}

.test2 {
    content: compact(value1 value2 false value3);
}

.test3 {
    content: compact(value1, value2 false, value3);
}
```

Resulting CSS:

```
.test1 {
  content: value1, value2, value3; }

.test2 {
  content: value1 value2 value3; }

.test3 {
  content: value1, value2 false, value3; }
```

 This fixes leafo/scssphp-compass#3 because the transition mixin uses compact() quite a bit.

This might also be interesting for leafo/scssphp#89.
