### PR TITLE
Do not require "dev-master" of "leafo/scssphp"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Compass for scssphp",
     "homepage": "http://leafo.net/scssphp/",
     "require": {
-        "leafo/scssphp": "dev-master"
+        "leafo/scssphp": "~0.1"
     },
     "authors": [
         {


### PR DESCRIPTION
Do not require "dev-master" of "leafo/scssphp" but the current stable version. This will allow others to require a stable version of "leafo/scssphp" in their `composer.json` file, too.
